### PR TITLE
[YDS-Divider] Divider 추가

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/atom/Divider.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/atom/Divider.kt
@@ -72,11 +72,13 @@ class Divider : View {
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val width = MeasureSpec.getSize(widthMeasureSpec)
+        val height = MeasureSpec.getSize(heightMeasureSpec)
 
         if (direction == HORIZONTAL) {
-            setMeasuredDimension(measuredWidth, dividerThicknessInPx)
+            setMeasuredDimension(width, dividerThicknessInPx)
         } else {
-            setMeasuredDimension(dividerThicknessInPx, measuredHeight)
+            setMeasuredDimension(dividerThicknessInPx, height)
         }
     }
 

--- a/DesignSystem/src/main/java/com/yourssu/design/system/atom/Divider.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/atom/Divider.kt
@@ -1,0 +1,134 @@
+package com.yourssu.design.system.atom
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.graphics.Canvas
+import android.graphics.drawable.ShapeDrawable
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.*
+import androidx.core.content.ContextCompat
+import com.yourssu.design.R
+import com.yourssu.design.system.language.ComponentGroup
+import com.yourssu.design.undercarriage.size.dpToIntPx
+
+class Divider : View {
+    constructor(context: Context) : this(context, null)
+
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
+        initView(context, attrs)
+    }
+
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : this(context, attrs)
+
+    var direction: Int = HORIZONTAL
+        set(direction) {
+            field = direction
+            setDividerInfo()
+            requestLayout()
+        }
+
+    var dividerThickness: Int = THIN
+        set(thickness) {
+            field = thickness
+            setDividerInfo()
+            requestLayout()
+        }
+
+    @ColorInt
+    private var dividerColor: Int = ContextCompat.getColor(context, R.color.borderNormal)
+
+    @Px
+    private var dividerThicknessInPx: Int = 0
+
+    private var dividerDrawable: ShapeDrawable = ShapeDrawable()
+
+
+    private fun initView(context: Context, attrs: AttributeSet?) {
+        if (attrs != null) {
+            val attributes: TypedArray = context.obtainStyledAttributes(attrs, R.styleable.Divider)
+            direction =
+                attributes.getInteger(R.styleable.Divider_direction, HORIZONTAL)
+
+            dividerThickness = attributes.getInteger(R.styleable.Divider_dividerThickness, THIN)
+
+            setDividerInfo()
+
+            attributes.recycle()
+        } else {
+            setDividerInfo()
+        }
+
+    }
+
+    private fun setDividerInfo() {
+        val thickness = getThickness(dividerThickness)
+        val color = getDividerColor(dividerThickness)
+
+        dividerThicknessInPx =
+            context.dpToIntPx(resources.getDimensionPixelSize(thickness).toFloat())
+        dividerColor = context.getColor(color)
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+
+        if (direction == HORIZONTAL) {
+            setMeasuredDimension(measuredWidth, dividerThicknessInPx)
+        } else {
+            setMeasuredDimension(dividerThicknessInPx, measuredHeight)
+        }
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+
+        if (direction == HORIZONTAL) {
+            dividerDrawable.setBounds(0, 0, width, dividerThicknessInPx)
+        } else {
+            dividerDrawable.setBounds(0, 0, dividerThicknessInPx, height)
+        }
+        dividerDrawable.paint.color = dividerColor
+        dividerDrawable.draw(canvas)
+    }
+
+    companion object {
+        const val HORIZONTAL = 0
+        const val VERTICAL = 1
+
+        const val THIN = 0
+        const val THICK = 1
+
+        @DimenRes
+        private fun getThickness(thickness: Int) = when (thickness) {
+            THIN -> R.dimen.thin
+            THICK -> R.dimen.thick
+            else -> R.dimen.thin
+        }
+
+        @ColorRes
+        private fun getDividerColor(thickness: Int) = when (thickness) {
+            THIN -> R.color.borderNormal
+            THICK -> R.color.borderThin
+            else -> R.color.borderNormal
+        }
+
+        fun Context.divider(block: Divider.() -> Unit) = Divider(this).run {
+            block.invoke(this)
+            this
+        }
+
+        fun ViewGroup.divider(block: Divider.() -> Unit) = Divider(this.context).run {
+            block.invoke(this)
+            this@divider.addView(this)
+            this
+        }
+
+        fun ComponentGroup.divider(block: Divider.() -> Unit) = Divider(this.componentContext).run {
+            block.invoke(this)
+            this@divider.addComponent(this)
+            this
+        }
+    }
+}

--- a/DesignSystem/src/main/java/com/yourssu/design/system/atom/Divider.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/atom/Divider.kt
@@ -72,7 +72,6 @@ class Divider : View {
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
 
         if (direction == HORIZONTAL) {
             setMeasuredDimension(measuredWidth, dividerThicknessInPx)

--- a/DesignSystem/src/main/res/values/attrs_divider.xml
+++ b/DesignSystem/src/main/res/values/attrs_divider.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="Divider">
+        <attr name="dividerThickness" format="enum">
+            <enum name="thin" value="0" />
+            <enum name="thick" value="1" />
+        </attr>
+        <attr name="direction" format="enum">
+            <enum name="horizontal" value="0" />
+            <enum name="vertical" value="1" />
+        </attr>
+    </declare-styleable>
+</resources>

--- a/DesignSystem/src/main/res/values/style_divider.xml
+++ b/DesignSystem/src/main/res/values/style_divider.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="thin">@dimen/minWidth</dimen>
+    <dimen name="thick">8dp</dimen>
+</resources>

--- a/app/yds-ui-tester/src/main/AndroidManifest.xml
+++ b/app/yds-ui-tester/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Light.YourssuDesignSystem">
+        <activity android:name=".DividerActivity" />
         <activity android:name=".DesignSystemListActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/yds-ui-tester/src/main/java/com/yourssu/yds_ui_tester/DesignSystemListActivity.kt
+++ b/app/yds-ui-tester/src/main/java/com/yourssu/yds_ui_tester/DesignSystemListActivity.kt
@@ -35,6 +35,15 @@ class DesignSystemListActivity : AppCompatActivity() {
                         startActivity(Intent(this@DesignSystemListActivity, MainActivity::class.java))
                     }
                 }
+                text {
+                    text = "Divider"
+                    typo = Typo.Title1
+                    width = ViewGroup.LayoutParams.MATCH_PARENT
+                    gravity = Gravity.CENTER
+                    setOnClickListener {
+                        startActivity(Intent(this@DesignSystemListActivity, DividerActivity::class.java))
+                    }
+                }
             })
     }
 }

--- a/app/yds-ui-tester/src/main/java/com/yourssu/yds_ui_tester/DividerActivity.kt
+++ b/app/yds-ui-tester/src/main/java/com/yourssu/yds_ui_tester/DividerActivity.kt
@@ -1,0 +1,24 @@
+package com.yourssu.yds_ui_tester
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ObservableBoolean
+import com.yourssu.yds_ui_tester.databinding.ActivityDividerBinding
+
+class DividerActivity : AppCompatActivity() {
+    lateinit var binding: ActivityDividerBinding
+
+    var isThick = ObservableBoolean(false)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_divider)
+
+        binding.activity = this
+        binding.buttonChangeThickness.setOnClickListener {
+            val currentValue = isThick.get()
+            isThick.set(!currentValue)
+        }
+    }
+}

--- a/app/yds-ui-tester/src/main/res/layout/activity_divider.xml
+++ b/app/yds-ui-tester/src/main/res/layout/activity_divider.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout>
+
+    <data>
+
+        <import type="com.yourssu.design.system.atom.Divider" />
+
+        <variable
+            name="activity"
+            type="com.yourssu.yds_ui_tester.DividerActivity" />
+    </data>
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        tools:context=".DividerActivity">
+
+        <com.yourssu.design.system.atom.Text
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="30dp"
+            android:text="Divider - horizontal, thin" />
+
+        <com.yourssu.design.system.atom.Divider
+            android:id="@+id/divider"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:direction="horizontal"
+            app:dividerThickness="thin" />
+
+        <com.yourssu.design.system.atom.Text
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Divider - horizontal, thick" />
+
+        <com.yourssu.design.system.atom.Divider
+            android:id="@+id/data_binding_divider"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:direction="horizontal"
+            app:dividerThickness="thick" />
+
+        <com.yourssu.design.system.atom.Text
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="30dp"
+            android:text="Divider - vertical, thin" />
+
+        <com.yourssu.design.system.atom.Divider
+            android:layout_width="wrap_content"
+            android:layout_height="30dp"
+            android:layout_gravity="center"
+            app:direction="vertical"
+            app:dividerThickness="thin" />
+
+        <com.yourssu.design.system.atom.Text
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Divider - vertical, thick" />
+
+        <com.yourssu.design.system.atom.Divider
+            android:layout_width="wrap_content"
+            android:layout_height="30dp"
+            android:layout_gravity="center"
+            app:direction="vertical"
+            app:dividerThickness="thick" />
+
+        <com.yourssu.design.system.atom.Text
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="30dp"
+            android:text="Divider DataBinding" />
+
+        <com.yourssu.design.system.atom.Divider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:direction="horizontal"
+            app:dividerThickness="@{activity.isThick ? Divider.THICK : Divider.THIN}" />
+
+        <Button
+            android:id="@+id/button_change_thickness"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Change Divider thickness" />
+
+    </LinearLayout>
+</layout>


### PR DESCRIPTION
특이사항으로 뷰의 맞춤속성에서 ```thickness``` 속성이 이미 다른 ```styleable```에 정의되어있어 임시로 ```dividerThickness```란 네이밍으로 정의해두었습니다.


아래 스크린샷은 yds-ui-tester 모듈에 추가한 divider 테스트 액티비티 사진입니다
<img src="https://user-images.githubusercontent.com/39683194/127495491-fd172262-3cf4-4c15-b408-226740518cf2.png" width="25%" height="25%">
 