### PR TITLE
[BUGFIX] PlainButton 리싸이클러뷰 내에서 텍스트 vertical center align 안되는 버그 수정

### DIFF
--- a/DesignSystem/src/main/res/layout/layout_plain_button.xml
+++ b/DesignSystem/src/main/res/layout/layout_plain_button.xml
@@ -20,7 +20,8 @@
         <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:gravity="center">
 
             <com.yourssu.design.system.atom.IconView
                 android:id="@+id/plainButtonLeftIcon"


### PR DESCRIPTION
커뮤니티 대댓글 더보기 컴포넌트 구현하던 중 버그를 발견한 거 같아서 픽스했습니다.
예전 Toggle에서 발생한 케이스랑 유사한 거 같아서 레이아웃에서 gravity를 명시적으로 주어서 해결했습니다.

변경 전에는 텍스트가 rightIcon 상단으로 몰려있는 것을 확인할 수 있고,
따로 gravity를 명시적으로 준 이후에는 변경 후 처럼 중앙정렬되어 표시됩니다.


 

|변경 전|변경 후|비교|
|---|---|---|
|![image](https://user-images.githubusercontent.com/39683194/147239288-06780f2f-42b3-4fe2-aba6-04bd8526f61b.png)|![image](https://user-images.githubusercontent.com/39683194/147239384-9e9b6233-330c-4aef-8837-8fd364e00bff.png)|![image](https://user-images.githubusercontent.com/39683194/147239733-07fcc4e9-81e8-48e3-bb3e-b3d322e4a8b2.png)|