### PR TITLE
[BUGFIX] BottomSheet 레이아웃 하단 일부 잘리는 현상 수정

### DIFF
--- a/DesignSystem/src/main/res/layout/layout_bottom_sheet.xml
+++ b/DesignSystem/src/main/res/layout/layout_bottom_sheet.xml
@@ -16,7 +16,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:fitsSystemWindows="true">
 
             <View
                 android:layout_width="wrap_content"


### PR DESCRIPTION
# 버그 설명
BottomSheet에서 레이아웃 하단 일부분이 잘리는 현상입니다.

# 재현 방법  

```yds-ui-tester``` 모듈의 ```MainActivity``` 클래스 에서
27번라인 ```private val list = listOf(1, 2, 3, 4, 5, ....)```을 ```private val list = listOf(1, 2, 3)```로 변경시 재현 가능

재현환경
- Pixel 3a API 30(AVD)
- Galaxy S20 API 30

API28 AVD에서는 정상작동 확인

### 기기화면

<p align="center">
<img src="https://user-images.githubusercontent.com/39683194/147851841-35f3f40d-cac0-43a9-9731-089c0c6926ec.png" width="30%" height="30%">
</p>

### 레이아웃 인스펙터
![image](https://user-images.githubusercontent.com/39683194/147851940-bbf7303e-170e-416f-b495-9380641b99bd.png)
 

# 발생 원인
BaseFullDialog.kt(31L)
```kotlin
window?.setDecorFitsSystemWindows(false)
```
setDecorFitsSystemWindows를 false를 설정하여 시스템바 뒤에 윈도우를 배치했으므로 해당 현상이 발생하는 것으로 추정됩니다.
# 해결 방법
바텀시트 레이아웃에서 바텀시트의 content를 포함하는 부모 레이아웃인 LinearLayout에 [fitsSystemWindows](https://developer.android.com/reference/android/view/View#attr_android:fitsSystemWindows) 속성을 true로 설정해주었습니다.
```XML
android:fitsSystemWindows="true"
```

# 반영 후 

### 기기화면

<p align="center">
<img src="https://user-images.githubusercontent.com/39683194/147854220-2ee58f81-4c6c-422f-8e09-9da09f82d49d.png" width="30%" height="30%">
</p>

### 레이아웃 인스펙터

<p align="center">
<img width="307" alt="레이아웃인스펙터" src="https://user-images.githubusercontent.com/39683194/147854223-7619b31d-bc4f-462e-84ac-e03edb544441.png">
</p>







