### PR TITLE
[YDS] 차후 ReadMoreText 구현을 위해 Text를 상속 가능하도록 변경

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/atom/Text.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/atom/Text.kt
@@ -8,7 +8,7 @@ import com.yourssu.design.system.foundation.Typo
 import com.yourssu.design.system.foundation.Typography
 import com.yourssu.design.undercarriage.size.getDimenFloat
 
-class Text: AppCompatTextView {
+open class Text: AppCompatTextView {
     constructor(context: Context) : super(context) {
         initView(context, null)
     }


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/39683194/148213198-b3bfa6d3-971d-4f9e-a215-f5a1bdab6a65.png" width="50%" height="50%">

커뮤니티의 더보기 텍스트(사진)가 YDS에 컴포넌트로 추가될 예정입니다.([슬랙 스레드 링크](https://yourssu.slack.com/archives/C01U696R2JJ/p1640344205321800))
다른 플랫폼 같은 경우는 기존에 구현되어 있는 Text로도 대응이 가능해 보이나,
'더보기'에만 클릭 이벤트가 있어 안드로이드에서는 기존 Text만으로는 대응이 어렵다고 판단됩니다. 
추가적인 내부 로직을 상속해서 구현할 필요가 있다고 판단되어 Text 클래스를 미리 상속 가능하도록 변경했습니다.
