### PR TITLE
[Bugfix] 바텀시트 잔상 현상 수정

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/undercarriage/base/BaseFullDialog.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/undercarriage/base/BaseFullDialog.kt
@@ -29,15 +29,12 @@ abstract class BaseFullDialog: Dialog {
     private fun setFullDialog(isAttachWindow: Boolean = false) {
         if (isAttachWindow && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             window?.setDecorFitsSystemWindows(false)
-            window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
             val insetController: WindowInsetsController? = window?.insetsController
             // insetController?.hide(WindowInsets.Type.statusBars() or WindowInsets.Type.navigationBars())
             insetController?.systemBarsBehavior = WindowInsetsController.BEHAVIOR_SHOW_BARS_BY_SWIPE
         } else if (!isAttachWindow && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
             window?.requestFeature(Window.FEATURE_NO_TITLE)
-            window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-
             window?.decorView?.systemUiVisibility =
                 View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
         }

--- a/DesignSystem/src/main/res/values/style_dialog.xml
+++ b/DesignSystem/src/main/res/values/style_dialog.xml
@@ -6,5 +6,6 @@
         <item name="android:windowContentOverlay">@null</item>
         <item name="windowActionBarOverlay">false</item>
         <item name="colorPrimaryVariant">@android:color/transparent</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 </resources>


### PR DESCRIPTION
API31이전 버젼 일부 AVD와 API31 AVD/실기기에서 확인된 바텀시트 잔상 현상을 수정했습니다.
다음 환경에서 테스트 후 해당 문제가 수정된 것을 확인했습니다
- API31 Galaxy S20 (SM-G981N)
- API30 Pixel XL (AVD)
- API28 Pixel 3a XL (AVD)

특히 api31 이전 버젼에서는 AVD에서만 확인되고 실기기에서 재현되지 않던 현상이라 다른 분들도 한 번씩 확인해주시면 좋을 것 같습니다

## 수정 전
https://user-images.githubusercontent.com/39683194/153590966-e649381e-5466-49e9-95fc-99a5ace9054f.mp4

## 수정 후
https://user-images.githubusercontent.com/39683194/153590859-dbcefecb-be47-4ed5-8541-724d56cff973.mp4







