### PR TITLE
[Bugfix] PlainButton 리싸이클러뷰 스크롤 시 상태 반영되지 않는 현상 수정

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/atom/PlainButton.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/atom/PlainButton.kt
@@ -88,7 +88,7 @@ class PlainButton @JvmOverloads constructor(
                 setButtonInfo()
             }
 
-            MotionEvent.ACTION_UP -> {
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 isPressed = false
                 setButtonInfo()
             }


### PR DESCRIPTION
# 버그 설명 
PlainButton이 클릭 된 상태로 리싸이클러뷰 내에서 스크롤 시 터치를 뗐을 때도 상태가 반영되지 않는 현상입니다.

# 재현 방법
리싸이클러 뷰 내의 PlainButton을 누른 채로 스크롤 시 재현 가능

# 원인
다양한 뷰의 터치 이벤트 중 기존 ```PlainButton```는   ```ACTION_DOWN``` , ```ACTION_UP``` 이벤트에 대해 대응이 되어 있었습니다.
그러나 ```ACTION_CANCEL``` 이벤트는 대응이 안되어 있었는데, 
해당 이벤트는  해당 뷰에 대한 제스쳐 이벤트가 취소 되었을 때 발생합니다.
대표적인 예로 리싸이클러뷰 내에 있는 뷰를 클릭한 상태로 스크롤을 할 때, 
스크롤을 처리 하기 위해 해당 뷰가 아닌 상위 뷰가 제스쳐를 처리하면서 해당 이벤트가 발생하는 걸로 알고 있습니다.
그 외에도 안드로이드 프레임워크에 의해 몇몇 이벤트가 드랍 되면서 해당 이벤트가 발생할 수도 있는데 [공식문서](https://developer.android.com/reference/android/view/MotionEvent#consistency-guarantees)에서도 해당 문제에 대응하기 위해 뷰에서는 ```ACTION_CANCEL```이벤트를 처리하는 것을 권고하고 있습니다.

# 해결 방법
```ACTION_CANCEL``` 이벤트도 ```ACTION_UP```과 동일하게 이벤트를 처리하도록 코드를 수정했습니다.

# 수정 전

https://user-images.githubusercontent.com/39683194/155318951-ca99e713-dcb7-482f-be88-c3ff4a9a71e6.mp4

터치를 뗐을 때도 PlainButton이 pressed 상태가 유지되는 것을 확인할 수 있습니다.

# 수정 후
https://user-images.githubusercontent.com/39683194/155319012-35aad08d-54b6-403c-9910-45303070ab81.mp4

PlainButton이 ```ACTION_CANCEL```이벤트도 ```ACTION_UP```이벤트와 동일하게 처리하면서, pressed 상태가 정상적으로 돌아가는 것을 확인할 수 있습니다.