### PR TITLE
[Bugfix] TopBarButton 클릭리스너 호출이 두번 되는 현상 수정

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/atom/TopBarButton.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/atom/TopBarButton.kt
@@ -109,7 +109,6 @@ class TopBarButton : LinearLayout {
 
             MotionEvent.ACTION_UP -> {
                 setTopBarButtonInfo()
-                performClick()
             }
         }
         return true


### PR DESCRIPTION
# 버그 설명 
TopBarButton에서 클릭리스너를 설정하고 클릭 시 클릭리스너가 두 번 실행되는 버그입니다.
# 재현 방법
특별한 조건 없이 TopBarButton에 클릭 리스너를 설정하고 클릭 시 클릭리스너가 두번 실행됩니다.

# 원인
```onTouchEvent``` 함수에서 ```super.onTouchEvent(event)``` 호출을 통해 클릭이 처리된 후에도
```ACTION_UP```이벤트를 처리하면서 ```performClick()```을 호출하므로 클릭리스너가 두 번 호출됩니다. 

# 해결 방법
```performClick()```를 호출하지 않도록 코드를 수정했습니다.

## 수정 전
터치 한 번시 performClick과 클릭 리스너 로그가 두 번씩 출력되는 것을 확인할 수 있습니다.

https://user-images.githubusercontent.com/39683194/157692914-97c829be-ad06-4177-bf3c-eb96b63bc120.mp4



## 수정  후
터치 한 번시 performClick과 클릭 리스너 로그가 한 번씩 출력되는 것을 확인할 수 있습니다.

https://user-images.githubusercontent.com/39683194/157693386-dabdb6d4-713c-4c40-bc76-0593e3eb5f11.mp4


