### PR TITLE
[QA] TabBar 스크롤 모드 시 중앙정렬 안되던 현상 수정

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/component/TabBar.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/component/TabBar.kt
@@ -95,7 +95,7 @@ class TabBar : ConstraintLayout {
     }
 
     private fun updatePaddingForFixed() {
-        val slidingTabStrip = binding.tabLayout.getChildAt(0) as LinearLayout
+        val slidingTabStrip = binding.tabLayout.getChildAt(SLIDING_TAB_STRIP_INDEX) as LinearLayout
         for (index in 0 until slidingTabStrip.childCount) {
             slidingTabStrip.getChildAt(index).apply {
                 updateLayoutParams {
@@ -152,7 +152,7 @@ class TabBar : ConstraintLayout {
     }
 
     private fun updatePaddingForScrollable() {
-        val slidingTabStrip = binding.tabLayout.getChildAt(0) as LinearLayout
+        val slidingTabStrip = binding.tabLayout.getChildAt(SLIDING_TAB_STRIP_INDEX) as LinearLayout
         for (index in 0 until slidingTabStrip.childCount) {
             if (index == 0) {
                 slidingTabStrip.getChildAt(index).apply {
@@ -257,6 +257,7 @@ class TabBar : ConstraintLayout {
     annotation class TabBarMode
 
     companion object {
+        private const val SLIDING_TAB_STRIP_INDEX = 0
         const val MODE_SCROLLABLE = 0
         const val MODE_FIXED = 1
     }

--- a/DesignSystem/src/main/java/com/yourssu/design/system/component/TabBar.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/component/TabBar.kt
@@ -4,13 +4,16 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.widget.LinearLayout
 import androidx.annotation.IntDef
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.viewpager.widget.ViewPager
 import com.google.android.material.tabs.TabLayout
 import com.yourssu.design.R
 import com.yourssu.design.databinding.LayoutTabBarBinding
+import com.yourssu.design.system.language.WRAP_CONTENT
 import com.yourssu.design.system.language.backgroundColor
 import com.yourssu.design.undercarriage.size.dpToIntPx
 
@@ -59,18 +62,9 @@ class TabBar : ConstraintLayout {
     }
 
     private fun setTabBarInfo() {
-        binding.tabLayout.background
         if (tabMode == MODE_SCROLLABLE) {
-            binding.tabLayout.updatePadding(
-                left = context.dpToIntPx(16f),
-                right = context.dpToIntPx(16f)
-            )
             binding.tabLayout.tabMode = TabLayout.MODE_SCROLLABLE
         } else {
-            binding.tabLayout.updatePadding(
-                left = context.dpToIntPx(0f),
-                right = context.dpToIntPx(0f)
-            )
             binding.tabLayout.tabMode = TabLayout.MODE_FIXED
         }
 
@@ -93,18 +87,52 @@ class TabBar : ConstraintLayout {
 
     fun addTab(tab: TabLayout.Tab) {
         binding.tabLayout.addTab(tab)
+        if (tabMode == MODE_SCROLLABLE) {
+            updatePaddingForScrollable()
+        } else {
+            updatePaddingForFixed()
+        }
+    }
+
+    private fun updatePaddingForFixed() {
+        val slidingTabStrip = binding.tabLayout.getChildAt(0) as LinearLayout
+        for (index in 0 until slidingTabStrip.childCount) {
+            slidingTabStrip.getChildAt(index).apply {
+                updateLayoutParams {
+                    width = WRAP_CONTENT
+                }
+                updatePadding(
+                    0, 0, 0, 0
+                )
+            }
+        }
     }
 
     fun addTab(tab: TabLayout.Tab, setSelected: Boolean) {
         binding.tabLayout.addTab(tab, setSelected)
+        if (tabMode == MODE_SCROLLABLE) {
+            updatePaddingForScrollable()
+        } else {
+            updatePaddingForFixed()
+        }
     }
 
     fun addTab(tab: TabLayout.Tab, position: Int) {
         binding.tabLayout.addTab(tab, position)
+        if (tabMode == MODE_SCROLLABLE) {
+            updatePaddingForScrollable()
+        } else {
+            updatePaddingForFixed()
+        }
     }
 
     fun addTab(tab: TabLayout.Tab, position: Int, setSelected: Boolean) {
         binding.tabLayout.addTab(tab, position, setSelected)
+        if (tabMode == MODE_SCROLLABLE) {
+            updatePaddingForScrollable()
+        } else {
+            updatePaddingForFixed()
+        }
     }
 
     fun clearOnTabSelectedListeners() {
@@ -123,6 +151,42 @@ class TabBar : ConstraintLayout {
         return binding.tabLayout.tabCount
     }
 
+    private fun updatePaddingForScrollable() {
+        val slidingTabStrip = binding.tabLayout.getChildAt(0) as LinearLayout
+        for (index in 0 until slidingTabStrip.childCount) {
+            if (index == 0) {
+                slidingTabStrip.getChildAt(index).apply {
+                    updateLayoutParams {
+                        width = context.dpToIntPx(104f)
+                    }
+                    updatePadding(
+                        left = context.dpToIntPx(16f)
+                    )
+                }
+
+            } else if (index == slidingTabStrip.childCount - 1) {
+                slidingTabStrip.getChildAt(index).apply {
+                    updateLayoutParams {
+                        width = context.dpToIntPx(104f)
+                    }
+                    updatePadding(
+                        right = context.dpToIntPx(16f)
+                    )
+                }
+
+            } else {
+                slidingTabStrip.getChildAt(index).apply {
+                    updateLayoutParams {
+                        width = WRAP_CONTENT
+                    }
+                    updatePadding(
+                        0, 0, 0, 0
+                    )
+                }
+            }
+        }
+    }
+
     fun getTabGravity(): Int {
         return binding.tabLayout.tabGravity
     }
@@ -137,18 +201,30 @@ class TabBar : ConstraintLayout {
 
     fun removeTab(tab: TabLayout.Tab) {
         binding.tabLayout.removeTab(tab)
+        if (tabMode == MODE_SCROLLABLE) {
+            updatePaddingForScrollable()
+        } else {
+            updatePaddingForFixed()
+        }
     }
 
     fun removeTabAt(position: Int) {
         binding.tabLayout.removeTabAt(position)
+        if (tabMode == MODE_SCROLLABLE) {
+            updatePaddingForScrollable()
+        } else {
+            updatePaddingForFixed()
+        }
     }
 
     fun selectTab(tab: TabLayout.Tab) {
+        tab.select()
         binding.tabLayout.selectTab(tab)
     }
 
     fun selectTab(tab: TabLayout.Tab, updateIndicator: Boolean) {
-        binding.tabLayout.selectTab(tab, updateIndicator)
+        if (updateIndicator) tab.select()
+        binding.tabLayout.selectTab(tab)
     }
 
     fun setScrollPosition(

--- a/DesignSystem/src/main/res/drawable/selector_indicator.xml
+++ b/DesignSystem/src/main/res/drawable/selector_indicator.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/bottomBarSelected" android:state_selected="true" />
+    <item android:drawable="@android:color/transparent" android:state_selected="false" />
+</selector>

--- a/DesignSystem/src/main/res/layout/layout_tab_bar.xml
+++ b/DesignSystem/src/main/res/layout/layout_tab_bar.xml
@@ -4,20 +4,19 @@
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="48dp">
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:backgroundTint="@color/bgElevated"
-            android:clipToPadding="false"
             app:layout_constraintBottom_toTopOf="@id/divider"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:tabIndicatorColor="@color/bottomBarSelected"
-            app:tabIndicatorHeight="2dp"
-            app:tabMode="fixed"
+            app:tabGravity="center"
+            app:tabIndicatorHeight="0dp"
+            app:tabMaxWidth="105dp"
             app:tabPaddingEnd="0dp"
             app:tabPaddingStart="0dp" />
 

--- a/DesignSystem/src/main/res/layout/layout_tab_fixed.xml
+++ b/DesignSystem/src/main/res/layout/layout_tab_fixed.xml
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="46dp">
+    android:layout_height="48dp"
+    android:orientation="vertical">
 
     <com.yourssu.design.system.atom.Text
         android:id="@android:id/text1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="46dp"
+        android:gravity="center"
         android:singleLine="true"
         android:textColor="@drawable/selector_tab_text_color"
-        app:typo="button2"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:typo="button2" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <View
+        android:id="@+id/selected_indicator"
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:background="@drawable/selector_indicator" />
+
+</androidx.appcompat.widget.LinearLayoutCompat>

--- a/DesignSystem/src/main/res/layout/layout_tab_scrollable.xml
+++ b/DesignSystem/src/main/res/layout/layout_tab_scrollable.xml
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="88dp"
-    android:layout_height="46dp">
+    android:layout_height="48dp"
+    android:orientation="vertical">
 
     <com.yourssu.design.system.atom.Text
         android:id="@android:id/text1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="88dp"
+        android:layout_height="46dp"
+        android:gravity="center"
         android:singleLine="true"
         android:textColor="@drawable/selector_tab_text_color"
-        app:typo="button2"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:typo="button2" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <View
+        android:id="@+id/selected_indicator"
+        android:layout_width="88dp"
+        android:layout_height="2dp"
+        android:background="@drawable/selector_indicator" />
+
+</androidx.appcompat.widget.LinearLayoutCompat>


### PR DESCRIPTION
# 설명 
기존 탭바에서 스크롤 모드 시 중앙 정렬이 안되던 현상을 수정했습니다.

# 수정 전

https://user-images.githubusercontent.com/39683194/162200526-040ccdcb-f9d3-40ed-9c8e-3b933a29c55f.mp4

총 6개의 탭에서 3~4번째 탭 클릭시 중앙에서 약간 벗어나는 위치에 선택된 탭이 위치된 것을 확인할 수 있습니다.
# 수정 후

https://user-images.githubusercontent.com/39683194/162200569-867dc52a-a455-44aa-b929-7666be85eadf.mp4

수정 전과 달리 총 6개의 탭에서 3~4번째 탭 클릭시 선택된 탭이 중앙에 위치되는 것을 확인할 수 있습니다.

