### PR TITLE
[Bugfix] BoxButton의 scrollable뷰 안에서 스크롤 시 상태 반영되지 않는 현상 수정

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/atom/BoxButton.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/atom/BoxButton.kt
@@ -280,16 +280,16 @@ class BoxButton : LinearLayout {
     }
 
     override fun onTouchEvent(event: MotionEvent?): Boolean {
+        super.onTouchEvent(event)
         if (event != null) {
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
                     isPressed = true
                     setBoxButtonInfo()
                 }
-                MotionEvent.ACTION_UP -> {
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                     isPressed = false
                     setBoxButtonInfo()
-                    performClick() // 손을 떼는 순간만 인식해야함
                 }
             }
         }


### PR DESCRIPTION
# 버그 설명 
BoxButton이 클릭 된 상태로 스크롤 가능한 뷰 내에서 스크롤 시 터치를 뗐을 때도 상태가 반영되지 않는 현상입니다

# 재현 방법
스크롤이 가능한 뷰 내에서 BoxButton을 누른 채로 스크롤 시 재현 가능합니다

# 원인
#80 PR과 동일합니다

# 해결 방법
```ACTION_CANCEL``` 이벤트도 ```ACTION_UP```과 동일하게 이벤트를 처리하도록 코드를 수정했습니다.

# 수정 전
https://user-images.githubusercontent.com/39683194/167867207-258169ed-477e-4ee3-8d15-b1718b774c7e.mp4


BoxButton의 테두리 부분을 보면 터치를 뗐을 때도 pressed 상태가 유지되는 것을 확인할 수 있습니다.

# 수정 후

https://user-images.githubusercontent.com/39683194/167867274-ac82b991-d8e6-426c-a916-b7bdf8bf13b5.mp4

BoxButton의 ```ACTION_CANCEL```이벤트도 ```ACTION_UP```이벤트와 동일하게 처리하면서 pressed 상태가 정상적으로 돌아가는 것을 확인할 수 있습니다.


