### PR TITLE
[Bugfix] Button류 Typo의 Text 잘리는 현상 수정

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/atom/Text.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/atom/Text.kt
@@ -3,6 +3,7 @@ package com.yourssu.design.system.atom
 import android.content.Context
 import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.view.updatePadding
 import com.yourssu.design.R
 import com.yourssu.design.system.foundation.Typo
 import com.yourssu.design.system.foundation.Typography
@@ -64,7 +65,8 @@ open class Text: AppCompatTextView {
         // 줄 간 간격인 lineSpacing 이자 (topPadding, bottomPadding) 의 합
         val lineSpacing = figmaLineHeight - fontLineHeight
 
-        setPadding(0, lineSpacing.toInt() / 2, 0, lineSpacing.toInt() / 2)
-        setLineSpacing(lineSpacing, 1f)
+        val padding = if (lineSpacing <= 0) 0 else lineSpacing.toInt() / 2
+        updatePadding(top = padding, bottom = padding)
+        if (lineSpacing >= 0) setLineSpacing(lineSpacing, 1f)
     }
 }


### PR DESCRIPTION
# 버그 설명 
Text의 Typo를 Button0 ~ Button4로 설정 시 텍스트가 잘리는 현상입니다.

# 재현 방법
![image](https://user-images.githubusercontent.com/39683194/177159179-e8f9403f-329c-4989-9be7-c9fb6011707e.png)

해당 타이포로 설정할 경우 텍스트, 이모지에서 해당 현상을 관찰할 수 있으나
텍스트의 경우 Font의 영역이 descent영역까지 텍스트(예를 들면 g) 등으로 설정 시 쉽게 관찰가능합니다.

# 원인
안드로이드가 텍스트를 그리는 방법과 Figma에서 디자이너가 인식하는 텍스트를 그리는 방법이 달라 
Text내부적으로 그 차이를 맞추기 위해 별도의 보정 로직이 들어가있습니다.
해당 로직에서 Button류의 typo가 보정값이 음수로 나오게되는데
이 값을 기반으로 Text의 ```lineSpacing```과 ```padding```을 설정하여 일어나는 현상으로 추정됩니다. 

# 해결 방법
일단 해당 typo의 경우 padding은 음수값이 설정되는 경우를 0으로 설정하도록 하였고,
lineSpacing은 무시하도록 처리하였습니다.
다만 이렇게 될 경우 디자인과의 씽크가 맞지 않게 되는데 이는 임시 조치이고 
추후 계속 연구 통해 씽크를 맞춰나가야합니다. 

# 수정 전
<img width="221" alt="image" src="https://user-images.githubusercontent.com/39683194/177159042-21e57d1e-7fb9-44e7-8028-028cda7e9c14.png">

<img width="531" alt="image" src="https://user-images.githubusercontent.com/39683194/177159459-bd7ba91e-f947-45a5-9354-5bafe80dae8e.png">

# 수정 후

![image](https://user-images.githubusercontent.com/39683194/177159575-f3cff65d-f794-4474-8d49-fe5faed240e3.png)

<img width="391" alt="image" src="https://user-images.githubusercontent.com/39683194/177159627-2cb4f8a5-e0da-473e-ba13-8c189c81a06d.png">

