### PR TITLE
[YDS-CheckBox]아이콘 버그 수정.

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/atom/Checkbox.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/atom/Checkbox.kt
@@ -25,6 +25,11 @@ class Checkbox @JvmOverloads constructor(
     private val binding: LayoutCheckBoxBinding =
         LayoutCheckBoxBinding.inflate(LayoutInflater.from(context), this, true)
 
+    init {
+        // 이게 없으면 라이브러리 사용자가 초기에 isSelected나 isDisabled의 값을 직접 대입안해주면 호출안됨.
+        setState()
+    }
+
     var size: Int = SMALL
         set(size) {
             field = size

--- a/app/storybook/src/main/res/layout/fragment_checkbox.xml
+++ b/app/storybook/src/main/res/layout/fragment_checkbox.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <import type="com.yourssu.design.system.foundation.Icon" />
+
         <import type="com.yourssu.design.system.atom.BoxButton" />
+
         <variable
             name="viewModel"
             type="com.yourssu.storybook.atom.CheckboxViewModel" />
@@ -21,37 +24,37 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:onClick="@{() -> viewModel.changeBackground()}"
-            android:background="@{viewModel.componentBackgroundColor}">
+            android:background="@{viewModel.componentBackgroundColor}"
+            android:onClick="@{() -> viewModel.changeBackground()}">
 
             <com.yourssu.design.system.atom.Checkbox
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                app:label="@{viewModel.textString}"
-                app:size="@{viewModel.size}"
-                app:isSelected="@{viewModel.isSelect}"
                 app:isDisabled="@{viewModel.isDisable}"
+                app:isSelected="@{viewModel.isSelect}"
+                app:label="@{viewModel.textString}"
                 app:selectedListener="@{viewModel.selectedStateListener}"
-                 />
+                app:size="@{viewModel.size}" />
 
             <!-- 안내 텍스트 -->
             <com.yourssu.design.system.atom.Text
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginRight="8dp"
-                android:textColor="@color/textPrimary"
                 android:layout_gravity="bottom|right"
+                android:layout_marginRight="8dp"
                 android:text="Click Background to change Color"
+                android:textColor="@color/textPrimary"
                 app:typo="subtitle2" />
+
             <com.yourssu.design.system.atom.Text
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginRight="8dp"
-                android:textColor="@drawable/white000"
-                android:alpha=".5"
                 android:layout_gravity="bottom|right"
+                android:layout_marginRight="8dp"
+                android:alpha=".5"
                 android:text="Click Background to change Color"
+                android:textColor="@drawable/white000"
                 app:typo="subtitle2" />
         </FrameLayout>
 
@@ -63,8 +66,8 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="16dp"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:padding="16dp">
 
                 <com.yourssu.design.system.atom.Text
                     android:layout_width="wrap_content"
@@ -72,15 +75,15 @@
                     android:gravity="center_vertical"
                     android:text="Label"
                     android:textColor="@color/textPrimary"
-                    app:typo="subtitle2"/>
+                    app:typo="subtitle2" />
 
                 <com.yourssu.design.system.atom.SimpleTextField
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:layout_marginBottom="8dp"
-                    android:text="Checkbox"
-                    android:onTextChanged="@{viewModel.onTextChangedListener}"/>
+                    android:onTextChanged="@{viewModel.onTextChangedListener}"
+                    android:text="Checkbox" />
 
                 <com.yourssu.design.system.atom.Text
                     android:layout_width="wrap_content"
@@ -88,7 +91,7 @@
                     android:gravity="center_vertical"
                     android:text="Size"
                     android:textColor="@color/textPrimary"
-                    app:typo="subtitle2"/>
+                    app:typo="subtitle2" />
 
                 <com.yourssu.design.system.atom.BoxButton
                     android:id="@+id/sizeSelect"
@@ -105,35 +108,40 @@
                     android:layout_width="match_parent"
                     android:layout_height="40dp"
                     android:gravity="center_vertical">
+
                     <com.yourssu.design.system.atom.Text
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
                         android:text="isSelect"
                         android:textColor="@color/textPrimary"
-                        app:typo="subtitle2"/>
+                        app:typo="subtitle2" />
+
                     <com.yourssu.design.system.atom.Toggle
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         app:isSelected="@{viewModel.isSelect}"
-                        app:selectedListener="@{viewModel.selectSelectListener}"/>
+                        app:selectedListener="@{viewModel.selectSelectListener}" />
                 </LinearLayout>
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="40dp"
                     android:gravity="center_vertical">
+
                     <com.yourssu.design.system.atom.Text
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
                         android:text="isDisable"
                         android:textColor="@color/textPrimary"
-                        app:typo="subtitle2"/>
+                        app:typo="subtitle2" />
+
                     <com.yourssu.design.system.atom.Toggle
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         app:isSelected="@{viewModel.isDisable}"
-                        app:selectedListener="@{viewModel.disableSelectListener}"/>
+                        app:selectedListener="@{viewModel.disableSelectListener}" />
                 </LinearLayout>
             </LinearLayout>
         </ScrollView>


### PR DESCRIPTION
기존 문제 및 수정내용)
YDS라이브러리를 사용하는 쪽에서 isSelected나 isDisabled값을 초기에 설정 안해준다면(즉,이 두 프로퍼티에 대한 데이터 바인딩을 안하고 리스너나 아이콘 크기에 대해서만 바인딩어댑터를 사용한다면) 체크 아이콘이 초깃값으로 설정 안되던 버그 수정.

기존문제 사진
![image](https://user-images.githubusercontent.com/67176829/177938466-0e4a7ab8-d204-48d7-ad0c-7c83d44276d5.png)


초깃값 이미지 설정을 위한 init 추가 이후
![image](https://user-images.githubusercontent.com/67176829/177938266-15f87866-eefd-4776-b2be-275e31ad5eaa.png)
