### PR TITLE
[bottomsheet] 다양한 환경에서 사용가능하게 scrollview 제거

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/atom/BottomSheet.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/atom/BottomSheet.kt
@@ -34,13 +34,13 @@ class BottomSheet constructor(context: Context): BaseFullDialog(context), Compon
 
     override fun show() {
         super.show()
-        binding.bottomSheetLayout.startAnimation(AnimationUtils.loadAnimation(context, R.anim.popup_in_motion_m))
+        binding.bottomSheetContent.startAnimation(AnimationUtils.loadAnimation(context, R.anim.popup_in_motion_m))
         binding.dim.startAnimation(AnimationUtils.loadAnimation(context, R.anim.fade_in_motion_m))
     }
 
     override fun dismiss() {
         binding.dim.startAnimation(AnimationUtils.loadAnimation(context, R.anim.fade_out_motion_m))
-        binding.bottomSheetLayout.startAnimation(AnimationUtils.loadAnimation(context, R.anim.popup_out_motion_m).apply {
+        binding.bottomSheetContent.startAnimation(AnimationUtils.loadAnimation(context, R.anim.popup_out_motion_m).apply {
             setAnimationListener(object : Animation.AnimationListener {
                 override fun onAnimationRepeat(animation: Animation?) {}
                 override fun onAnimationStart(animation: Animation?) {}

--- a/DesignSystem/src/main/res/layout/layout_bottom_sheet.xml
+++ b/DesignSystem/src/main/res/layout/layout_bottom_sheet.xml
@@ -22,22 +22,18 @@
             <View
                 android:layout_width="wrap_content"
                 android:layout_height="88dp" />
-            
-            <ScrollView
-                android:id="@+id/bottomSheetLayout"
+
+
+
+            <LinearLayout
+                android:id="@+id/bottomSheetContent"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@drawable/bottom_sheet_background">
-    
-                <LinearLayout
-                    android:id="@+id/bottomSheetContent"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:minHeight="88dp"
-                    android:orientation="vertical"
-                    android:paddingTop="20dp"
-                    android:paddingBottom="20dp" />
-            </ScrollView>
+                android:background="@drawable/bottom_sheet_background"
+                android:minHeight="88dp"
+                android:orientation="vertical"
+                android:paddingTop="20dp"
+                android:paddingBottom="20dp" />
         </LinearLayout>
     </FrameLayout>
 </layout>


### PR DESCRIPTION
ex) 가로모드 에서 picker 사용 가능 (scrollview 가 없어야 picker 크기 자동 계산 됨)
ex2) bottomsheet 상단에 고정 뷰를 만들 수 있음
(scrollview 는 필요하면 추가해서 써도 되니까)