### PR TITLE
[YDS] TopBar에 들어가는 TopBarButton의 isDisabled 프로퍼티 컨트롤 가능하도록 수정

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/component/TopBar.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/component/TopBar.kt
@@ -92,6 +92,18 @@ class TopBar @JvmOverloads constructor(
         binding.endLeftButton.isEnabled = isEnabled
     }
 
+    fun setStartButtonDisabled(isDisabled: Boolean) {
+        binding.startButton.isDisabled = isDisabled
+    }
+
+    fun setEndRightButtonDisabled(isDisabled: Boolean) {
+        binding.endRightButton.isDisabled = isDisabled
+    }
+
+    fun setEndLeftButtonDisabled(isDisabled: Boolean) {
+        binding.endLeftButton.isDisabled = isDisabled
+    }
+
     companion object {
         @JvmStatic
         @BindingAdapter("startIcon")
@@ -169,6 +181,24 @@ class TopBar @JvmOverloads constructor(
         @BindingAdapter("endLeftButtonEnabled")
         fun setEndLeftButtonEnabled(topBar: TopBar, isEnabled: Boolean) {
             topBar.setEndLeftButtonEnabled(isEnabled)
+        }
+
+        @JvmStatic
+        @BindingAdapter("startButtonDisabled")
+        fun setStartButtonDisabled(topBar: TopBar, isDisabled: Boolean) {
+            topBar.setStartButtonDisabled(isDisabled)
+        }
+
+        @JvmStatic
+        @BindingAdapter("endRightButtonDisabled")
+        fun setEndRightButtonDisabled(topBar: TopBar, isDisabled: Boolean) {
+            topBar.setEndRightButtonDisabled(isDisabled)
+        }
+
+        @JvmStatic
+        @BindingAdapter("endLeftButtonDisabled")
+        fun setEndLeftButtonDisabled(topBar: TopBar, isDisabled: Boolean) {
+            topBar.setEndLeftButtonDisabled(isDisabled)
         }
     }
 }

--- a/app/storybook/src/main/java/com/yourssu/storybook/component/TopBarViewModel.kt
+++ b/app/storybook/src/main/java/com/yourssu/storybook/component/TopBarViewModel.kt
@@ -10,18 +10,21 @@ import com.yourssu.storybook.BaseViewModel
 class TopBarViewModel(application: Application) : BaseViewModel(application) {
     val titleLiveData = MutableLiveData("Title")
 
+    val startButtonDisabled: MutableLiveData<Boolean> = MutableLiveData(false)
     val startIcon: MutableLiveData<Int> = MutableLiveData(Icon.ic_arrow_left_line)
     val startIconText: MutableLiveData<String> = MutableLiveData("ic_arrow_left_line")
     val startIconVisibility: MutableLiveData<Boolean> = MutableLiveData(true)
 
     val startText: MutableLiveData<String> = MutableLiveData("닫기")
 
+    val endRightButtonDisabled: MutableLiveData<Boolean> = MutableLiveData(false)
     val endRightIcon: MutableLiveData<Int> = MutableLiveData(Icon.ic_search_line)
     val endRightIconText: MutableLiveData<String> = MutableLiveData("ic_search_line")
     val endRightIconVisibility: MutableLiveData<Boolean> = MutableLiveData(true)
 
     val endRightText: MutableLiveData<String> = MutableLiveData("알림")
 
+    val endLeftButtonDisabled: MutableLiveData<Boolean> = MutableLiveData(false)
     val endLeftIcon: MutableLiveData<Int> = MutableLiveData(Icon.ic_bell_line)
     val endLeftIconText: MutableLiveData<String> = MutableLiveData("ic_bell_line")
     val endLeftIconVisibility: MutableLiveData<Boolean> = MutableLiveData(true)
@@ -73,6 +76,24 @@ class TopBarViewModel(application: Application) : BaseViewModel(application) {
     val endLeftIconSelectListener = object : Toggle.SelectedListener {
         override fun onSelected(boolean: Boolean) {
             endLeftIconVisibility.value = boolean
+        }
+    }
+
+    val startDisabledSelectListener = object : Toggle.SelectedListener {
+        override fun onSelected(boolean: Boolean) {
+            startButtonDisabled.value = boolean
+        }
+    }
+
+    val endRightDisabledSelectListener = object : Toggle.SelectedListener {
+        override fun onSelected(boolean: Boolean) {
+            endRightButtonDisabled.value = boolean
+        }
+    }
+
+    val endLeftDisabledSelectListener = object : Toggle.SelectedListener {
+        override fun onSelected(boolean: Boolean) {
+            endLeftButtonDisabled.value = boolean
         }
     }
 }

--- a/app/storybook/src/main/res/layout/fragment_top_bar.xml
+++ b/app/storybook/src/main/res/layout/fragment_top_bar.xml
@@ -39,10 +39,13 @@
                 app:title="@{viewModel.titleLiveData}"
                 app:startIcon="@{viewModel.startIconVisibility ? viewModel.startIcon : null}"
                 app:startText="@{viewModel.startText}"
+                app:startButtonDisabled="@{viewModel.startButtonDisabled}"
                 app:endRightIcon="@{viewModel.endRightIconVisibility ? viewModel.endRightIcon : null}"
                 app:endRightText="@{viewModel.endRightText}"
+                app:endRightButtonDisabled="@{viewModel.endRightButtonDisabled}"
                 app:endLeftIcon="@{viewModel.endLeftIconVisibility ? viewModel.endLeftIcon : null}"
-                app:endLeftText="@{viewModel.endLeftText}"/>
+                app:endLeftText="@{viewModel.endLeftText}"
+                app:endLeftButtonDisabled="@{viewModel.endLeftButtonDisabled}"/>
         </FrameLayout>
 
         <ScrollView
@@ -72,6 +75,25 @@
                     android:imeOptions="actionDone"
                     android:onTextChanged="@{viewModel.onTitleTextChangedListener}"
                     android:text="Title" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:gravity="center_vertical">
+                    <com.yourssu.design.system.atom.Text
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:gravity="center_vertical"
+                        android:layout_weight="1"
+                        android:text="StartButtonDisabled"
+                        android:textColor="@color/textPrimary"
+                        app:typo="subtitle2"/>
+                    <com.yourssu.design.system.atom.Toggle
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:isSelected="@{viewModel.startButtonDisabled}"
+                        app:selectedListener="@{viewModel.startDisabledSelectListener}"/>
+                </LinearLayout>
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -134,6 +156,25 @@
                         android:layout_height="40dp"
                         android:gravity="center_vertical"
                         android:layout_weight="1"
+                        android:text="EndRightButtonDisabled"
+                        android:textColor="@color/textPrimary"
+                        app:typo="subtitle2"/>
+                    <com.yourssu.design.system.atom.Toggle
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:isSelected="@{viewModel.endRightButtonDisabled}"
+                        app:selectedListener="@{viewModel.endRightDisabledSelectListener}"/>
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:gravity="center_vertical">
+                    <com.yourssu.design.system.atom.Text
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:gravity="center_vertical"
+                        android:layout_weight="1"
                         android:text="EndRightIcon"
                         android:textColor="@color/textPrimary"
                         app:typo="subtitle2"/>
@@ -177,6 +218,25 @@
                     android:imeOptions="actionDone"
                     android:onTextChanged="@{viewModel.onEndRightTextChangedListener}"
                     android:text="알림" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:gravity="center_vertical">
+                    <com.yourssu.design.system.atom.Text
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:gravity="center_vertical"
+                        android:layout_weight="1"
+                        android:text="EndLeftButtonDisabled"
+                        android:textColor="@color/textPrimary"
+                        app:typo="subtitle2"/>
+                    <com.yourssu.design.system.atom.Toggle
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:isSelected="@{viewModel.endLeftButtonDisabled}"
+                        app:selectedListener="@{viewModel.endLeftDisabledSelectListener}"/>
+                </LinearLayout>
 
                 <LinearLayout
                     android:layout_width="match_parent"


### PR DESCRIPTION
Topbar클래스에

```kotlin
// 코드 일부분
fun setEndLeftButtonDisabled(isDisabled: Boolean) {
    binding.endLeftButton.isDisabled = isDisabled // endLeftButton는 TopbarButton
}

companion object {
	@JvmStatic
	@BindingAdapter("endLeftButtonDisabled")
	fun setEndLeftButtonDisabled(topBar: TopBar, isDisabled: Boolean) {
    	topBar.setEndLeftButtonDisabled(isDisabled)    
	}
}
```

코드를 추가하면서, 

TopbarButton의 isDisabled 프로퍼티를 아래 코드처럼 컨트롤 할 수 있게 됐습니다.

```xml
app:endLeftButtonDisabled="@{viewModel.endLeftButtonDisabled}"
```

![image-20220804152457522](https://user-images.githubusercontent.com/20380647/182782216-672a084e-1b60-445a-ab8a-43bb8eacfd59.png)


YDS Storybook의 Topbar 화면에, TopbarButton마다 Disabled 옵션을 추가했습니다.

