### PR TITLE
annotation 라이브러리 AndroidX 마이그레이션

### DIFF
--- a/DesignSystem/build.gradle
+++ b/DesignSystem/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation "com.android.support:support-annotations:28.0.0"
+    implementation "androidx.annotation:annotation:1.4.0"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official


### PR DESCRIPTION
support-annotations 라이브러리를 androidx로 마이그레이션하고 빌드 속도 개선을 위해 jetifier를 비활성화했습니다.