### PR TITLE
[YDS] 릴리즈 노트 작성 자동화

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,35 @@
+name-template: "Release $RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
+
+# 해당 라벨이 붙은 pr은 변경내용에 추가 안함.
+exclude-labels:
+  - 'skip'
+
+# 각 pr의 라벨에 따라서 카테고리가 나뉨.
+categories:
+  - title: '🚀 Features'
+    label: 'features'
+  - title: '🛠 Modify'
+    label: 'modify'
+  - title: '🔥 Hotfix'
+    label: 'hotfix'
+
+#  각 pr의 내용 설명 뒤에 추가될 정보. 아래와 같은 형태로 알맞은 카테고리에 문장이 추가됨.
+#  - pr제목 @pr올린사람ID (#pr번호)
+change-template: '- $TITLE @$AUTHOR (#$NUMBER) '
+
+# 카테고리 분류가 안되는 pr은 Uncategorized 타이틀로 분류.
+# 여기서 $CHANGES는 해당 PR의 제목임.
+template: |
+  ## Uncategorized
+  $CHANGES
+
+# 각 pr의 라벨에 따라서 버전 업 기준이 달라짐.
+version-resolver:
+  major:
+    labels:
+      - "features"
+  minor:
+    labels:
+      - "modify"
+  default: patch

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+# 해당 워크플로우의 이름.
+name: Release Drafter
+#조건. 마스터 브랜치에 푸쉬될때,
+on:
+  push:
+    branches:
+      - master
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # 해당 confing파일에 정의한 대로 릴리즈 노트가 작성됨.
+          config-name: config.yml
+        env:
+          # 자동생성되는 환경변수.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
기본적인 사용법은 각 pr을 머지하기 전에 label을 달아주면 됩니다. 
버전 x.y.z 중 

x를 하나 올리는 major 업데이트에 해당하는 경우) 새로운 기능 추가와 같이 다른 팀들도 다함께 버전을 올릴 때
해당 pr에는 features 라벨을 달아주면 됨. 

y를 하나 올리는 minor 업데이트에 해당하는 경우) 기능 자체의 변화는 없지만, 디자인 변화 혹은 내부 로직 같은 변화가 생겼을 때
해당 pr에는 modify 라벨을 달아주면 됨. 

z를 하나 올리는 patch 업데이트에 해당하는 경우) 내부 로직에만 변화가 생겼을 경우.
해당 pr에는 hotfix 라벨을 달아주면 됨.

만약 릴리즈 자동화 노트에 게시하고 싶지 않은 pr이라면, skip라벨을 달아주면 됩니다.

아무 라벨도 달려있지 않으면 uncategorized로 분류돼서 릴리즈 자동화 노트에 작성됩니다. 

![image](https://user-images.githubusercontent.com/67176829/193532275-55ff880c-3cf3-4d82-b05a-546d9a553d59.png)
위 사진의 경우 8개의 pr이 쌓여서 만들어진 릴리즈 노트 내용입니다.
기존의 버전은 1.0.2였으나, 쌓인 pr들 중 가장 큰 버전 업데이트의 내용을 반영해서 1.0.2->2.0.0으로 자동 작성된 모습입니다.

쌓인 릴리즈 자동화 노트를 반영해서 릴리즈하고 싶다면, 
edit-> publish release를 누르면 정식 출시가 됩니다.    

사용 주의 사항)
1. 릴리즈 자동화 노트에 추가하고 싶은 pr이라면, 해당 pr의 성격에 맞는 라벨을 제대로 달아주는게 좋음.
2. 릴리즈 자동화 노트에 반영하기 싫은 pr이라면, skip라벨을 달아줄 것.