### PR TITLE
gradle 버전 최신화

### DIFF
--- a/DesignSystem/build.gradle
+++ b/DesignSystem/build.gradle
@@ -27,11 +27,11 @@ def versionProperties = new Properties()
 versionProperties.load(new FileInputStream(file("../version.properties")))
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode ((System.getenv("BUILD_NUMBER") as Integer ?: 10000))
         versionName versionProperties['versionName']
         vectorDrawables.useSupportLibrary = true
@@ -51,6 +51,14 @@ android {
     }
     kotlinOptions {
         jvmTarget = '11'
+        freeCompilerArgs += [
+                "-Xjvm-default=all",
+        ]
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion compose_version
+        kotlinCompilerVersion kotlin_version
     }
 
     buildFeatures {
@@ -62,20 +70,20 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation "androidx.annotation:annotation:1.4.0"
+    implementation "androidx.annotation:annotation:1.5.0"
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 
     implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.material:material:1.3.1"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.5.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
+    implementation 'androidx.activity:activity-compose:1.6.1'
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"

--- a/DesignSystem/src/main/java/com/yourssu/design/compose/base/NoRippleButton.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/compose/base/NoRippleButton.kt
@@ -32,7 +32,9 @@ fun NoRippleButton(
 ) {
     val contentColor by colors.contentColor(enabled, interactionSource)
     Surface(
+        onClick = onClick,
         modifier = modifier,
+        enabled = enabled,
         shape = shape,
         color = colors.backgroundColor(enabled, interactionSource).value,
         contentColor = contentColor,
@@ -41,11 +43,7 @@ fun NoRippleButton(
             contentColor
         ) else null,
         elevation = elevation?.elevation(enabled, interactionSource)?.value ?: 0.dp,
-        onClick = onClick,
-        enabled = enabled,
-        role = Role.Button,
-        interactionSource = interactionSource,
-        indication = null
+        interactionSource = interactionSource
     ) {
         CompositionLocalProvider(LocalContentAlpha provides contentColor.alpha) {
             ProvideTextStyle(value = MaterialTheme.typography.button) {

--- a/app/storybook/build.gradle
+++ b/app/storybook/build.gradle
@@ -8,7 +8,7 @@ def versionProperties = new Properties()
 versionProperties.load(new FileInputStream(file("../../version.properties")))
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     // 당연하지만 배포용은 아니고 release 테스트용
     signingConfigs {
@@ -23,7 +23,7 @@ android {
     defaultConfig {
         applicationId "com.yourssu.storybook"
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode (System.getenv("BUILD_NUMBER") as Integer ?: 10000) // 로컬에서 10000 번으로 빌드됨
         versionName versionProperties['versionName']
 
@@ -72,14 +72,14 @@ dependencies {
     implementation project(path: ':DesignSystem')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.activity:activity-ktx:1.5.0'
-    implementation 'androidx.fragment:fragment-ktx:1.5.0'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.activity:activity-ktx:1.6.1'
+    implementation 'androidx.fragment:fragment-ktx:1.5.5'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 }

--- a/app/yds-ui-tester/build.gradle
+++ b/app/yds-ui-tester/build.gradle
@@ -9,7 +9,7 @@ def versionProperties = new Properties()
 versionProperties.load(new FileInputStream(file("../../version.properties")))
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     // 당연하지만 배포용은 아니고 release 테스트용
     signingConfigs {
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "com.yourssu.yds_android"
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 10000 // 배포용이 아니니까 변경 필요 없음
         versionName versionProperties['versionName']
 
@@ -60,12 +60,12 @@ dependencies {
     implementation project(path: ':DesignSystem')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'androidx.activity:activity-ktx:1.5.0'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.activity:activity-ktx:1.6.1'
+    implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.31"
-    ext.compose_version = "1.1.0"
+    ext.kotlin_version = "1.7.20"
+    ext.compose_version = "1.3.2"
 
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Jul 10 02:28:18 KST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
<h1>주의 사항</h1>
compose 버전도 같이 올리면서 targetSDK 33 으로 타케팅 되어야함
머지된 후에 해당 YDS 버전을 받는 프로젝트는 targetSDK 33이상으로 올려야 됨

어차피 바로 머지할 필요없으니 필요하다고 생각될때 머지하면 될듯..