### PR TITLE
라이브러리 배포 workflow 최신화

### DIFF
--- a/.github/workflows/deployLibraryYDS.yml
+++ b/.github/workflows/deployLibraryYDS.yml
@@ -5,41 +5,24 @@ on:
     branches: [ master ]
 
 jobs:
-  upload:
-
+  release:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Read versionName property
         id: release_version
-        uses: christian-draeger/read-properties@1.0.1
+        uses: christian-draeger/read-properties@1.1.1
         with:
           path: './version.properties'
-          property: 'versionName'
+          properties: 'versionName'
 
       - name: set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: '2.6'
-
-      - name: Install Bundle
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-
-      - name: Generate Credential File for Fastlane
-        run: |
-          echo "$PLAY_STORE_CREDENTIALS" > fastlane/play-store-credentials.json.b64
-          base64 -d -i fastlane/play-store-credentials.json.b64 > fastlane/play-store-credentials.json
-        env:
-          PLAY_STORE_CREDENTIALS: ${{ secrets.PLAY_STORE_CREDENTIALS }}
+        uses: actions/setup-java@v3
+          with:
+            java-version: '11'
+            distribution: 'temurin'
+            cache: gradle
 
       - name: Setting env
         run: |
@@ -55,18 +38,11 @@ jobs:
         run: ./gradlew --no-daemon :app:storybook:bundleProductionRelease
 
       - name: Create a GitHub release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.release_version.outputs.value }}
-          release_name: Release ${{ steps.release_version.outputs.value }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ steps.release_version.outputs.versionName }}
+          name: Release ${{ steps.release_version.outputs.versionName }}
 
       - name: Upload to Slack
-        run: curl -F file=@"app/storybook/build/outputs/bundle/productionRelease/YDS-StoryBook-${{ steps.release_version.outputs.value }}($BUILD_NUMBER)-production-release.aab" -F "initial_comment=YDS ${{ steps.release_version.outputs.value }} 라이브러리가 등록되었슈~ https://jitpack.io/#yourssu/YDS-Android    aab 파일은 스토어에 업로드 했슈~" -F "channels=${{ secrets.SLACK_CHANNEL_ID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" https://slack.com/api/files.upload
-
-      - name: Rename aab
-        run: mv app/storybook/build/outputs/bundle/productionRelease/YDS-StoryBook-${{ steps.release_version.outputs.value }}\($BUILD_NUMBER\)-production-release.aab app/storybook/build/outputs/bundle/productionRelease/app-production-release.aab
-
-      - name: Submit a new Internal Build to Play Store
-        run: bundle exec fastlane internal_release
+        run: curl -F "initial_comment=YDS ${{ steps.release_version.outputs.value }} 라이브러리가 등록되었슈~ https://jitpack.io/#yourssu/YDS-Android" -F "channels=${{ secrets.SLACK_CHANNEL_ID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" https://slack.com/api/files.upload


### PR DESCRIPTION
### 문제가 발생하던 setup-ruby를 포함해 fastlane 내부 테스트 배포 로직을 제거했습니다.

### 오래된 버전의 일부 액션을 최신 버전으로 갱신했습니다.
- checkout v2 -> v3
- setup-java v1 -> v3 (캐싱 추가)

### [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)와 [지원 중단](https://github.com/actions/create-release) 이슈의 영향을 받는 액션을 수정했습니다. 
- read-properties 1.0.1 -> 1.1.1
- create-release(archived) -> [action-gh-release](https://github.com/softprops/action-gh-release)

### Slack 메시지에서 aab 파일을 제거했습니다.

---

작업하면서 [release-drafter.yml](https://github.com/yourssu/YDS-Android/blob/develop/.github/workflows/release-drafter.yml) 관련해서 몇 가지 궁금한 점이 있었는데, 혹시 해당 기능을 현재 사용하고 있나요? 현재 배포 로직대로라면 release-drafter는 draft 단계의 릴리즈만 만들고 deployLibraryYDS는 별개로 실제 릴리즈를 또 진행할 것 같은데, 의도된 부분인지 궁금합니다. 만약 사용중이라면 다른 몇 가지 이슈(버전이 올바르게 생성되지 않는 이슈 등)도 수정해야 할 것 같습니다.