### PR TITLE
워크플로 오류 수정

### DIFF
--- a/.github/workflows/deployDevStoryBook.yml
+++ b/.github/workflows/deployDevStoryBook.yml
@@ -32,7 +32,7 @@ jobs:
       # 빌드에 필요한 환경변수를 세팅합니다.
       - name: Setting env
         run: |
-          echo "BUILD_NUMBER=$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
+          echo "BUILD_NUMBER=$(($GITHUB_RUN_NUMBER+139))" >> $GITHUB_ENV
           echo "STORE_PASSWORD=${{ secrets.STORE_PASSWORD }}" >> $GITHUB_ENV
           echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
           echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
@@ -47,4 +47,4 @@ jobs:
 
       # 빌드된 apk를 슬랙에 전송합니다.
       - name: Upload to Slack
-        run: curl -F file=@"app/storybook/build/outputs/apk/dev/release/YDS-StoryBook-${{ steps.release_version.outputs.value }}($BUILD_NUMBER)-dev-release.apk" -F "initial_comment=개발중인 YDS StoryBook이 나왔슈~" -F "channels=${{ secrets.SLACK_CHANNEL_ID_ANDROID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" https://slack.com/api/files.upload
+        run: curl -F file=@"app/storybook/build/outputs/apk/dev/release/YDS-StoryBook-${{ steps.release_version.outputs.versionName }}($BUILD_NUMBER)-dev-release.apk" -F "initial_comment=개발중인 YDS StoryBook이 나왔슈~" -F "channels=${{ secrets.SLACK_CHANNEL_ID_ANDROID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" https://slack.com/api/files.upload

--- a/.github/workflows/deployGooglePlay.yml
+++ b/.github/workflows/deployGooglePlay.yml
@@ -33,7 +33,7 @@ jobs:
       # 빌드에 필요한 환경변수를 세팅합니다.
       - name: Setting env
         run: |
-          echo "BUILD_NUMBER=$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
+          echo "BUILD_NUMBER=$(($GITHUB_RUN_NUMBER+20))" >> $GITHUB_ENV
           echo "STORE_PASSWORD=${{ secrets.STORE_PASSWORD }}" >> $GITHUB_ENV
           echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
           echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
@@ -82,4 +82,4 @@ jobs:
 
       # 슬랙에 완료 메시지를 전송합니다.
       - name: Send message to Slack
-        run: curl -d "text=YDS StoryBook ${{ steps.release_version.outputs.value }} 버전을 ${{ inputs.track }} 트랙에 배포했슈~ https://play.google.com/store/apps/details?id=com.yourssu.storybook" -d "channels=${{ secrets.SLACK_CHANNEL_ID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" -X POST https://slack.com/api/chat.postMessage
+        run: curl -d "text=YDS StoryBook ${{ steps.release_version.outputs.versionName }} 버전을 ${{ inputs.track }} 트랙에 배포했슈~ https://play.google.com/store/apps/details?id=com.yourssu.storybook" -d "channels=${{ secrets.SLACK_CHANNEL_ID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" -X POST https://slack.com/api/chat.postMessage

--- a/.github/workflows/deployGooglePlay.yml
+++ b/.github/workflows/deployGooglePlay.yml
@@ -82,4 +82,4 @@ jobs:
 
       # 슬랙에 완료 메시지를 전송합니다.
       - name: Send message to Slack
-        run: curl -d "text=YDS StoryBook ${{ steps.release_version.outputs.versionName }} 버전을 ${{ inputs.track }} 트랙에 배포했슈~ https://play.google.com/store/apps/details?id=com.yourssu.storybook" -d "channel=${{ secrets.SLACK_CHANNEL_ID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" -X POST https://slack.com/api/chat.postMessage
+        run: curl -d "text=YDS StoryBook ${{ steps.release_version.outputs.versionName }} 버전을 ${{ inputs.track }} 트랙에 배포했슈~ https://play.google.com/store/apps/details?id=com.yourssu.storybook" -d "channel=${{ secrets.SLACK_CHANNEL_ID_ANDROID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" -X POST https://slack.com/api/chat.postMessage

--- a/.github/workflows/deployGooglePlay.yml
+++ b/.github/workflows/deployGooglePlay.yml
@@ -82,4 +82,4 @@ jobs:
 
       # 슬랙에 완료 메시지를 전송합니다.
       - name: Send message to Slack
-        run: curl -d "text=YDS StoryBook ${{ steps.release_version.outputs.versionName }} 버전을 ${{ inputs.track }} 트랙에 배포했슈~ https://play.google.com/store/apps/details?id=com.yourssu.storybook" -d "channels=${{ secrets.SLACK_CHANNEL_ID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" -X POST https://slack.com/api/chat.postMessage
+        run: curl -d "text=YDS StoryBook ${{ steps.release_version.outputs.versionName }} 버전을 ${{ inputs.track }} 트랙에 배포했슈~ https://play.google.com/store/apps/details?id=com.yourssu.storybook" -d "channel=${{ secrets.SLACK_CHANNEL_ID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" -X POST https://slack.com/api/chat.postMessage

--- a/.github/workflows/deployLibraryYDS.yml
+++ b/.github/workflows/deployLibraryYDS.yml
@@ -57,4 +57,4 @@ jobs:
 
       # 슬랙에 완료 메시지를 전송합니다.
       - name: Send message to Slack
-        run: curl -d "text=YDS ${{ steps.release_version.outputs.value }} 라이브러리가 등록되었슈~ https://jitpack.io/#yourssu/YDS-Android" -d "channels=${{ secrets.SLACK_CHANNEL_ID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" -X POST https://slack.com/api/chat.postMessage
+        run: curl -d "text=YDS ${{ steps.release_version.outputs.versionName }} 라이브러리가 등록되었슈~ https://jitpack.io/#yourssu/YDS-Android" -d "channels=${{ secrets.SLACK_CHANNEL_ID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" -X POST https://slack.com/api/chat.postMessage

--- a/.github/workflows/deployLibraryYDS.yml
+++ b/.github/workflows/deployLibraryYDS.yml
@@ -57,4 +57,4 @@ jobs:
 
       # 슬랙에 완료 메시지를 전송합니다.
       - name: Send message to Slack
-        run: curl -d "text=YDS ${{ steps.release_version.outputs.versionName }} 라이브러리가 등록되었슈~ https://jitpack.io/#yourssu/YDS-Android" -d "channels=${{ secrets.SLACK_CHANNEL_ID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" -X POST https://slack.com/api/chat.postMessage
+        run: curl -d "text=YDS ${{ steps.release_version.outputs.versionName }} 라이브러리가 등록되었슈~ https://jitpack.io/#yourssu/YDS-Android" -d "channel=${{ secrets.SLACK_CHANNEL_ID }}" -H "Authorization:Bearer ${{ secrets.SLACK_WORKSPACE_TOKEN }}" -X POST https://slack.com/api/chat.postMessage

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,10 +16,10 @@
 default_platform(:android)
 
 platform :android do
-    # devRelease 버전의 aab를 빌드 후 내부 테스트 트랙에 배포합니다.
+    # productionRelease 버전의 aab를 빌드 후 내부 테스트 트랙에 배포합니다.
     desc "Submit to internal track"
     lane :internal do
-        gradle(task: 'bundle', flavor: 'Dev', build_type: 'Release', flags: '--no-daemon')
+        gradle(task: 'bundle', flavor: 'Production', build_type: 'Release', flags: '--no-daemon')
         upload_to_play_store(track: 'internal')
     end
 


### PR DESCRIPTION
#173 의 오류를 수정했습니다.

### GITHUB_RUN_NUMBER 초기화 대응
- 새로운 워크플로가 추가되면서 $GITHUB_RUN_NUMBER가 1로 돌아감 
- 기존의 버전코드보다 낮게 빌드되지 않도록 일정 숫자를 더해줌

### read-properties 관련 오류 수정
- read-properties가 복수의 property를 읽을 수 있게 바뀌면서 output을 받는 방식이 변경되어 대응

### flavor 관련 오류 수정
- dev 버전으로 빌드할 경우 패키지명에 .dev suffix가 붙어 Google Play 배포 불가
- 내부 테스트 트랙도 productionRelease로 빌드하도록 변경