### PR TITLE
PR 빌드시 signing 제거

### DIFF
--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -1,3 +1,4 @@
+# PR이 정상적으로 빌드되는지 확인하기 위한 워크플로입니다.
 name: Android Build
 
 on:
@@ -19,18 +20,10 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      # 빌드에 필요한 환경변수를 세팅합니다.
-      - name: Setting env
-        run: |
-          echo "BUILD_NUMBER=$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
-          echo "STORE_PASSWORD=${{ secrets.STORE_PASSWORD }}" >> $GITHUB_ENV
-          echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
-          echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
-
       # gradlew에 실행 권한을 부여합니다.
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # devRelease 버전의 apk를 빌드합니다.
+      # devDebug 버전의 apk를 빌드합니다.
       - name: Build with Gradle
-        run: ./gradlew --no-daemon :app:storybook:assembleDevRelease
+        run: ./gradlew --no-daemon :app:storybook:assembleDevDebug


### PR DESCRIPTION
### 발생 이슈
fork한 repo에서 PR을 보냈을 때(기여 등) Github Actions 서명에 필요한 secrets에 접근하지 못하는 문제

### 수정 사항
PR의 경우 빌드 여부만 체크하면 되므로, 기존 release 빌드에서 서명이 필요없는 debug 빌드로 변경했습니다.