### PR TITLE
[Refactor] Checkbox SelectedListener 파라미터 이름 리팩토링

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/atom/Checkbox.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/atom/Checkbox.kt
@@ -49,7 +49,7 @@ class Checkbox @JvmOverloads constructor(
         }
 
     interface SelectedListener {
-        fun onSelected(boolean: Boolean)
+        fun onSelected(selected: Boolean)
     }
 
     private var selectedListener: SelectedListener? = null


### PR DESCRIPTION
`Checkbox.SelectedListener`의 `onSelected(Boolean)` 메소드 파라미터 이름을 `selected`로 변경하였습니다.