### PR TITLE
[YDS-189] TabBar fixed 모드인 경우 width 1/n으로 반영되도록 수정

### DIFF
--- a/DesignSystem/src/main/java/com/yourssu/design/system/component/TabBar.kt
+++ b/DesignSystem/src/main/java/com/yourssu/design/system/component/TabBar.kt
@@ -64,8 +64,10 @@ class TabBar : ConstraintLayout {
     private fun setTabBarInfo() {
         if (tabMode == MODE_SCROLLABLE) {
             binding.tabLayout.tabMode = TabLayout.MODE_SCROLLABLE
+            binding.tabLayout.tabGravity = TabLayout.GRAVITY_START
         } else {
             binding.tabLayout.tabMode = TabLayout.MODE_FIXED
+            binding.tabLayout.tabGravity = TabLayout.GRAVITY_FILL
         }
 
         binding.tabLayout.tabRippleColor = null // disable ripple effect

--- a/DesignSystem/src/main/res/layout/layout_tab_bar.xml
+++ b/DesignSystem/src/main/res/layout/layout_tab_bar.xml
@@ -14,9 +14,7 @@
             app:layout_constraintBottom_toTopOf="@id/divider"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:tabGravity="center"
             app:tabIndicatorHeight="0dp"
-            app:tabMaxWidth="105dp"
             app:tabPaddingEnd="0dp"
             app:tabPaddingStart="0dp" />
 


### PR DESCRIPTION
## Summary
TabBar가 fixed모드인 경우 각 탭이 전체 너비의 1/n으로 반영되도록 수정했습니다

## Describe your changes
TabMode 별로 TabLayout의 gravity를 동적으로 변경하도록 수정했습니다.

### Before
<img src="https://github.com/yourssu/YDS-Android/assets/39683194/3a0ff95a-29a9-4bbc-9e4a-fb3ab2136a0f" width="30%" height="30%" />


### After
<img src="https://github.com/yourssu/YDS-Android/assets/39683194/0aa63fea-44b2-4e09-9f6f-d90e691a303d" width="30%" height="30%" />

## Issue
Fix #189 