### PR TITLE
[YDS-203] Compose Picker 리스너 맨 처음에 실행되는 문제 해결

### DIFF
--- a/compose/src/main/java/com/yourssu/design/system/compose/atom/Picker.kt
+++ b/compose/src/main/java/com/yourssu/design/system/compose/atom/Picker.kt
@@ -13,7 +13,10 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -22,6 +25,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.yourssu.design.system.compose.YdsTheme
 import com.yourssu.design.system.compose.base.YdsText
+import kotlinx.coroutines.CoroutineScope
 
 @Composable
 fun Picker(
@@ -97,7 +101,7 @@ private fun WheelPicker(
     val currentOnItemChange by rememberUpdatedState(onItemChange)
 
     // TODO: warning 뜨는거 고치기
-    LaunchedEffect(lazyListState.firstVisibleItemIndex) {
+    UpdateEffect(lazyListState.firstVisibleItemIndex) {
         currentOnItemChange?.invoke(lazyListState.firstVisibleItemIndex)
     }
 
@@ -156,6 +160,22 @@ private fun PickerItem(
                 YdsTheme.colors.textDisabled
             }
         )
+    }
+}
+
+/**
+ * The same as [LaunchedEffect] but skips the first invocation
+ */
+@Composable
+fun UpdateEffect(key: Any, block: suspend CoroutineScope.() -> Unit) {
+    var isTriggered by remember { mutableStateOf(false) }
+
+    LaunchedEffect(key) {
+        if (isTriggered) {
+            block()
+        } else {
+            isTriggered = true
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

WheelPicker의 `onItemChange` 함수 인자는 picker가 스크롤되어서 아이템이 바뀔 때마다 실행되는 리스너 함수입니다.

원래는 `lazyListState.firstVisibleItemIndex` 속성이 바뀔 때마다 함수를 실행시키도록 `LaunchedEffect` 블록으로 감싼 형태로 구현했었습니다.

그런데 이렇게 구현하면 UI가 맨처음 세팅될 때([초기 컴포지션](https://developer.android.com/jetpack/compose/lifecycle#lifecycle-overview))에도 리스너가 실행되는 문제가 있어서 `LaunchedEffect` 대신 `UpdateEffect`로 교체했습니다. `UpdateEffect`는 `LaunchedEffect`와 동작이 동일하지만 맨처음 컴포지션을 스킵하는 함수입니다.

## Issue

resolves #203 