### PR TITLE
develop에 병합되면 릴리즈 되도록 변경

### DIFF
--- a/.github/workflows/deployLibraryYDS.yml
+++ b/.github/workflows/deployLibraryYDS.yml
@@ -1,10 +1,11 @@
 # YDS 라이브러리를 깃헙에 배포하는 워크플로입니다.
+# 깃허브에 배포되면 자동으로 jitpack에 등록됩니다. (https://jitpack.io/#yourssu/YDS-Android)
 name: Deploy YDS Library
 
-# master 브랜치에 push가 발생하면 실행됩니다.
+# develop 브랜치에 push가 발생하면 실행됩니다.
 on:
   push:
-    branches: [ master ]
+    branches: [ develop ]
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

기존에는 master 브랜치까지 병합이 되어야 YDS 라이브러리가 배포되었는데, 이 문제 때문에
컴포넌트의 버그를 수정하는 등 어떤 변경사항이 바로 반영되어야 할 때 병목현상이 발생되는 것을 자주 경험하였습니다.

그래서 라이브러리 배포 시점을 master 브랜치에서 develop 브랜치로 옮기려고 합니다.

## 달라지는 부분

- 버전 네이밍
  - 앞으로 develop 브랜치에 PR을 올리실 때마다 `version.properties`의 버전을 하나 올려주셔야 합니다. 
  - 마이너한 업데이트(버그 픽스, 디자인 명세 변경 등)는 최하위 버전(x.y.z에서 z)을 올려주시면 되고
  - 컴포넌트 추가 등 마이너하지 않은(본인이 판단) 변경사항은 y버전을 올려주시면 됩니다.

## To reviewer

제가 제안하는 방향으로 바꾸었을 때 우려되는 부분 등 의견을 자유롭게 남겨주세요!
